### PR TITLE
Allow user to change package manager & reuse same terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,17 @@
     "package": "pnpm build && pnpm vsce package",
     "format:check": "prettier --config ./prettier.config.json --c ./src/**/*.ts",
     "format:write": "pnpm format:check --write"
+  },
+  "contributes": {
+    "configuration": {
+      "title": "Betterplace Vitest Runner",
+      "properties": {
+        "VitestRunner.executionArg": {
+          "type": "string",
+          "default": "pnpm",
+          "description": "The runner of the extension. You can replace it with \"docker exec -it <your-container-name> npx\" to execute vitest inside your dev container"
+        }
+      }
+    }
   }
 }

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -4,7 +4,7 @@ import { TextCase } from './types';
 import { flatMap } from './utils';
 import { RunVitestCommand, DebugVitestCommand } from './vscode';
 
-const caseText = new Set(['it', 'describe','test']);
+const caseText = new Set(['it', 'describe', 'test']);
 
 function tryGetVitestTestCase(
     typescript: typeof ts,

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,3 @@
+export enum TERMINAL {
+    Name = 'vitest runner'
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,94 +1,94 @@
-import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
 
 function buildVitestArgs(...args: string[]) {
-  const [path, ...rest] = args;
-  return ["vitest", "run", "--dir", path, "-t", ...rest];
+    const [path, ...rest] = args;
+    return ['vitest', 'run', '--dir', path, '-t', ...rest];
 }
 
 function buildCdArgs(path: string) {
-  return ["cd", path];
+    return ['cd', path];
 }
 
 export function findProjectRoot(filename: string) {
-  let packageJsonPath: string | undefined;
-  let dir = path.dirname(filename);
-  while (dir !== path.dirname(dir)) {
-    const testPath = path.join(dir, "package.json");
-    if (fs.existsSync(testPath)) {
-      packageJsonPath = testPath;
-      break;
+    let packageJsonPath: string | undefined;
+    let dir = path.dirname(filename);
+    while (dir !== path.dirname(dir)) {
+        const testPath = path.join(dir, 'package.json');
+        if (fs.existsSync(testPath)) {
+            packageJsonPath = testPath;
+            break;
+        }
+        dir = path.dirname(dir);
     }
-    dir = path.dirname(dir);
-  }
-  if (!packageJsonPath) throw new Error("Could not find package.json!");
-  return path.dirname(packageJsonPath);
+    if (!packageJsonPath) throw new Error('Could not find package.json!');
+    return path.dirname(packageJsonPath);
 }
 
 export function getFilePathRelativeToRoot(
-  projectRootPath: string,
-  filename: string
+    projectRootPath: string,
+    filename: string
 ) {
-  if (!projectRootPath) {
-    return path.dirname(filename);
-  }
-  return path.dirname(path.relative(projectRootPath, filename));
+    if (!projectRootPath) {
+        return path.dirname(filename);
+    }
+    return path.dirname(path.relative(projectRootPath, filename));
 }
 
 export function getRootAndCasePath(filename: string) {
-  const projectRootPath = findProjectRoot(filename);
-  const casePathRelativeToRoot = getFilePathRelativeToRoot(
-    projectRootPath,
-    filename
-  );
-  return {
-    projectRootPath,
-    casePathRelativeToRoot,
-  };
+    const projectRootPath = findProjectRoot(filename);
+    const casePathRelativeToRoot = getFilePathRelativeToRoot(
+        projectRootPath,
+        filename
+    );
+    return {
+        projectRootPath,
+        casePathRelativeToRoot
+    };
 }
 
 export function runInTerminal(text: string, filename: string) {
-  const { projectRootPath, casePathRelativeToRoot } =
-    getRootAndCasePath(filename);
-  const terminal = vscode.window.createTerminal(`vitest - ${text}`);
+    const { projectRootPath, casePathRelativeToRoot } =
+        getRootAndCasePath(filename);
+    const terminal = vscode.window.createTerminal(`vitest - ${text}`);
 
-  const caseNameStr = JSON.stringify(text);
+    const caseNameStr = JSON.stringify(text);
 
-  const cdArgs = buildCdArgs(projectRootPath);
-  terminal.sendText(cdArgs.join(" "), true);
+    const cdArgs = buildCdArgs(projectRootPath);
+    terminal.sendText(cdArgs.join(' '), true);
 
-  const vitestArgs = buildVitestArgs(casePathRelativeToRoot, caseNameStr);
-  const runnerArgs = ["pnpm", ...vitestArgs];
-  terminal.sendText(runnerArgs.join(" "), true);
-  terminal.show();
+    const vitestArgs = buildVitestArgs(casePathRelativeToRoot, caseNameStr);
+    const runnerArgs = ['pnpm', ...vitestArgs];
+    terminal.sendText(runnerArgs.join(' '), true);
+    terminal.show();
 }
 
 function buildDebugConfig(
-  cwd: string,
-  casePath: string,
-  text: string
+    cwd: string,
+    casePath: string,
+    text: string
 ): vscode.DebugConfiguration {
-  return {
-    name: "Debug vitest case",
-    request: "launch",
-    runtimeArgs: buildVitestArgs(casePath, text),
-    cwd,
-    runtimeExecutable: "pnpm",
-    skipFiles: ["<node_internals>/**"],
-    type: "pwa-node",
-    console: "integratedTerminal",
-    internalConsoleOptions: "neverOpen",
-  };
+    return {
+        name: 'Debug vitest case',
+        request: 'launch',
+        runtimeArgs: buildVitestArgs(casePath, text),
+        cwd,
+        runtimeExecutable: 'pnpm',
+        skipFiles: ['<node_internals>/**'],
+        type: 'pwa-node',
+        console: 'integratedTerminal',
+        internalConsoleOptions: 'neverOpen'
+    };
 }
 
 export function debugInTermial(text: string, filename: string) {
-  const { projectRootPath, casePathRelativeToRoot } =
-    getRootAndCasePath(filename);
-  const config = buildDebugConfig(
-    projectRootPath,
-    casePathRelativeToRoot,
-    text
-  );
-  vscode.debug.startDebugging(undefined, config);
+    const { projectRootPath, casePathRelativeToRoot } =
+        getRootAndCasePath(filename);
+    const config = buildDebugConfig(
+        projectRootPath,
+        casePathRelativeToRoot,
+        text
+    );
+    vscode.debug.startDebugging(undefined, config);
 }


### PR DESCRIPTION
I added the configuration to enable the extension settings. Now, users can override the `pnpm` runner with the one they prefer. Also, they can use the extension even when they code inside a dev container, which is a huge +. Finally let's create one terminal and reuse it, instead of creating one terminal for each test execution.

My first commit is a prettier execution, without any other changes. My changes are on the 2nd commit.